### PR TITLE
Add titles to past meetup events

### DIFF
--- a/content/events/2020-03-13-meetup.md
+++ b/content/events/2020-03-13-meetup.md
@@ -1,7 +1,7 @@
 ---
 layout: event
 image: '/img/meetup-header-with-logo.jpg'
-title: "NL-RSE Meetup"
+title: "NL-RSE Meetup: Dutch electricity Grid simulation, research communication and CI/CD"
 date: 2020-01-08
 ---
 

--- a/content/events/2020-11-20-meetup.md
+++ b/content/events/2020-11-20-meetup.md
@@ -1,7 +1,7 @@
 ---
 layout: event
 image: '/img/meetup-header-with-logo.jpg'
-title: "NL-RSE Meetup"
+title: "NL-RSE Meetup: Tools for digital humanities"
 date: 2020-10-05
 ---
 

--- a/content/events/2020-12-16-meetup.md
+++ b/content/events/2020-12-16-meetup.md
@@ -1,7 +1,7 @@
 ---
 layout: event
 image: '/img/meetup-header-with-logo.jpg'
-title: "NL-RSE Meetup"
+title: "NL-RSE Meetup: From a bash script to CWL"
 date: 2020-11-01
 ---
 

--- a/content/events/2021-02-11-meetup.md
+++ b/content/events/2021-02-11-meetup.md
@@ -1,7 +1,7 @@
 ---
 layout: event
 image: '/img/meetup-header-with-logo.jpg'
-title: "NL-RSE Meetup"
+title: "NL-RSE Meetup: Open Science Fund, DCCs and software reusability"
 date: 2021-01-26
 ---
 

--- a/content/events/2021-04-21-meetup.md
+++ b/content/events/2021-04-21-meetup.md
@@ -1,7 +1,7 @@
 ---
 layout: event
 image: '/img/meetup-header-with-logo.jpg'
-title: "NL-RSE Meetup"
+title: "NL-RSE Meetup: RSE groups at university medical centers"
 date: 2021-04-02
 ---
 

--- a/content/events/2021-06-11-meetup.md
+++ b/content/events/2021-06-11-meetup.md
@@ -1,7 +1,7 @@
 ---
 layout: event
 image: '/img/meetup-header-with-logo.jpg'
-title: "NL-RSE Meetup"
+title: "NL-RSE Meetup: Open Science, Intellectual Property and Code Literacy"
 date: 2021-05-18
 ---
 

--- a/content/events/2021-09-15-meetup.md
+++ b/content/events/2021-09-15-meetup.md
@@ -1,7 +1,7 @@
 ---
 layout: event
 image: '/img/meetup-header-with-logo.jpg'
-title: "NL-RSE Meetup"
+title: "NL-RSE Meetup: Reproducible research articles"
 date: 2021-06-28
 ---
 

--- a/content/events/2021-12-01-meetup.md
+++ b/content/events/2021-12-01-meetup.md
@@ -1,7 +1,7 @@
 ---
 layout: event
 image: '/img/meetup-header-with-logo.jpg'
-title: "NL-RSE Meetup"
+title: "NL-RSE Meetup: Software development in industry vs. academia"
 date: 2021-12-01
 ---
 

--- a/content/events/2022-03-08-meetup.md
+++ b/content/events/2022-03-08-meetup.md
@@ -1,7 +1,7 @@
 ---
 layout: event
 image: '/img/mikael-kristenson-6GjHwABuci4-unsplash.jpg'
-title: "NL-RSE Meetup"
+title: "NL-RSE Meetup: RSE career stages: from junior to group lead"
 date: 2022-03-08
 ---
 

--- a/content/pages/meetups.md
+++ b/content/pages/meetups.md
@@ -19,22 +19,22 @@ Speakers are usually but not exclusively members of the NL-RSE community (i.e. D
 * [15 June, 2023](/events/2023-06-15-meetup); Introduction to Automated software testing
 * [19 April, 2023](/events/2023-04-19-meetup); Bugs in research data and software
 
-
 ### 2022
 * [9 November, 2022](/events/2022-11-09-meetup); Should research software be free?
+* [8 March, 2022](/events/2022-03-08-meetup); RSE career stages: from junior to group lead
 
 ### 2021
-* [1 December, 2021](/events/2021-12-01-meetup); Online meetup
+* [1 December, 2021](/events/2021-12-01-meetup); Software development in industry vs. academia (Online meetup)
 * ~15 October, 2021; Online meetup~ [NL-RSE Road Show Event](/events/nl-rse-rse21)
-* [15 September, 2021](/events/2021-09-15-meetup); Online meetup
-* [11 June, 2021](/events/2021-06-11-meetup); Online meetup
-* [21 April, 2021](/events/2021-04-21-meetup); Online meetup
-* [11 February, 2021](/events/2021-02-11-meetup); Online meetup
+* [15 September, 2021](/events/2021-09-15-meetup); Reproducible research articles (Online meetup)
+* [11 June, 2021](/events/2021-06-11-meetup); Open Science, Intellectual Property and Code Literacy (Online meetup)
+* [21 April, 2021](/events/2021-04-21-meetup); RSE groups at university medical centers (Online meetup)
+* [11 February, 2021](/events/2021-02-11-meetup); Open Science Fund, DCCs and software reusability (Online meetup)
 
 ### 2020
-* [16 December, 2020](/events/2020-12-16-meetup); Online meetup
-* [20 November, 2020](/events/2020-11-20-meetup); Online meetup
-* [13 March, 2020](/events/2020-03-13-meetup)
+* [16 December, 2020](/events/2020-12-16-meetup); From a bash script to CWL (Online meetup)
+* [20 November, 2020](/events/2020-11-20-meetup); Tools for digital humanities (Online meetup)
+* [13 March, 2020](/events/2020-03-13-meetup); Dutch electricity Grid simulation, research communication and CI/CD
 
 ## Location of in person events
 


### PR DESCRIPTION
I was looking for a previous meetup, and realised that in the [list of events](https://nl-rse.org/event) a lot of events just say "NL-RSE meetup", which makes it difficult to find the right one. I've added titles to some of them.

For 2022-03-08-meetup, I used the title from Eventbrite, but maybe a different title might be more suitable?
For 2021-09-15-meetup (and before) there is no title on Eventbrite, so I just made up the titles
